### PR TITLE
add gulp-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Ismael Rivera <me@ismaelrivera.es>",
   "license": "ISC",
   "dependencies": {
+    "gulp-util": "^3.0.2",
     "request": "2.48.x",
     "through2": "0.6.x",
     "vinyl": "0.4.x"


### PR DESCRIPTION
`gulp-util` is referenced but is not an explicit dependency in `package.json`. This PR adds it as a dependency
