### PR TITLE
Added automatic retries when Rollbar POST fails.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "gulp-util": "3.0.x",
     "request": "2.48.x",
+    "requestretry": "^1.2.2",
     "through2": "0.6.x",
     "vinyl": "0.4.x"
   }


### PR DESCRIPTION
Rollbar sourcemap endpoint occasionally fails with TIMEOUT errors and so on.  Retry often corrects the problem so no reason we should blow up the task.  Wrapped the request library with the published requestretry library and used this to effect retries.  Logs when retries take place.
