### PR TITLE
sourceMappingURLPrefix should not be required

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function rollbar(options) {
     throw new PluginError(PLUGIN_NAME, 'Missing `version`!');
   }
   if (!options.sourceMappingURLPrefix) {
-    throw new PluginError(PLUGIN_NAME, 'Missing `sourceMappingURLPrefix`!');
+    options.sourceMappingURLPrefix = '';
   }
 
   function postSourcemap(file, encoding, callback) {


### PR DESCRIPTION
The api doesn't require setting the full path, hence it shouldn't be required by this plugin.